### PR TITLE
Fix Token Transfers

### DIFF
--- a/util/blockchain-write.js
+++ b/util/blockchain-write.js
@@ -47,7 +47,7 @@ const transfer = async (
           clist: [
             //capability to transfer
             {
-              name: "coin.TRANSFER",
+              name: `${tokenAddress}.TRANSFER`,
               args: [fromAcct, toAcct, +formatAmount(amount)]
             },
             //capability for gas


### PR DESCRIPTION
Uses the `tokenAddress` variable to add the correct capability